### PR TITLE
Fix npm install issue

### DIFF
--- a/Dockerfile.dev.front
+++ b/Dockerfile.dev.front
@@ -4,7 +4,8 @@ LABEL "repository"="https://github.com/uqmc/arapiles"
 LABEL "homepage"="https://github.com/uqmc/arapiles"
 
 WORKDIR /front
-RUN rm -rf ./node_modules/
+COPY src/front/package.json .
+RUN npm install
 COPY src/front/. .
 
 # Run frontend

--- a/Dockerfile.dev.front
+++ b/Dockerfile.dev.front
@@ -4,7 +4,7 @@ LABEL "repository"="https://github.com/uqmc/arapiles"
 LABEL "homepage"="https://github.com/uqmc/arapiles"
 
 WORKDIR /front
-COPY src/front/package.json .
+COPY src/front/package*.json .
 RUN npm install
 COPY src/front/. .
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,7 @@ services:
       - BACKEND_URI=http://localhost:3000
     volumes:
       - ./src/front:/front
+      - /front/node_modules  # mount node modules from built container
 
   # Database accessible at postgres://USER:PASSWORD@localhost/postgres
   db:


### PR DESCRIPTION
The changes to the Dockerfile are based off of [this](https://buddy.works/guides/how-dockerize-node-application) guide.

I had to mount the node_modules from the built container as a volume in the "live" container, otherwise when the `src/front` directory is mounted it overrides the node_modules from the build.